### PR TITLE
remove globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,6 @@ module.exports = {
 		es6: true,
 		node: true,
 	},
-	globals: {
-		OC: true,
-		OCA: true,
-		OCP: true
-	},
 	parserOptions: {
 		parser: 'babel-eslint',
 		ecmaVersion: 6


### PR DESCRIPTION
These globals are already defined in the environment `nextcloud` which is loaded by extending the config `plugin:nextcloud/recommended`.