### PR TITLE
Allow spaces after tabs for alignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ module.exports = {
 		indent: ['error', 'tab'],
 		'no-tabs': ['error', { allowIndentationTabs: true }],
 		'vue/html-indent': ['error', 'tab'],
+		// allow spaces after tabs for alignment
+		'no-mixed-spaces-and-tabs': ['error', 'smart-tabs'],
 		// only debug console
 		'no-console': ['error', { allow: ['error', 'warn', 'info', 'debug'] }],
 		// classes blocks


### PR DESCRIPTION
This is needed for proper alignment of comments in CSS code embedded in Vue files. For example:
```
-->/* Here starts a long comment that would be too long to have in a
--> * single line so is continued in the next one. */
```

Otherwise [it would need to be written](https://github.com/nextcloud/spreed/blob/eb7aa7b4938a9d16ab96815bc314dbe92cd5a850/src/FilesSidebarTabApp.vue#L309-L310) as
```
-->/* Here starts a long comment that would be too long to have in a
-->* single line so is continued in the next one. */
```
to prevent the linter from complaining.

See https://eslint.org/docs/rules/no-mixed-spaces-and-tabs#smart-tabs

**Important:** this change is needed only for the CSS code; the JavaScript code in Vue files already allows tabs followed by spaces for alignment, but I do not know why it works for JavaScript but not for CSS. So I might be using a wrong approach with this rule :-)

For reference, if adding this rule is not desired, an alternative to get properly aligned multiline comments in the CSS code embedded in Vue files would be to set the CSS code as `lang="scss"` and use:
```
-->// Here starts a long comment that would be too long to have in a
-->// single line so is continued in the next one.
```
